### PR TITLE
Implement stop and resume functionality

### DIFF
--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -9,9 +9,6 @@ from DAS.tools import *
 from DAS.results import *
 from DAS.observer import *
 from DAS.node import *
-import os
-import pickle
-import uuid
 
 class Simulator:
     """This class implements the main DAS simulator."""
@@ -276,13 +273,6 @@ class Simulator:
         trafficStatsVector = []
         malicious_nodes_not_added_count = 0
         steps = 0
-        unique_run_id = str(uuid.uuid4())
-        backup_folder = f"results/{self.execID}/backup"
-        if not os.path.exists(backup_folder):
-            os.makedirs(backup_folder)
-        backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
-        with open(backup_file, 'ab') as f:
-            pickle.dump(self.shape.__dict__, f)
 
         while(True):
             missingVector.append(missingSamples)
@@ -363,8 +353,6 @@ class Simulator:
                 break
             steps += 1
 
-        with open(backup_file, 'ab') as f:
-            pickle.dump("completed", f)
 
         for i in range(0,self.shape.numberNodes):
             if not self.validators[i].amIaddedToQueue :

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -281,11 +281,10 @@ class Simulator:
         if not os.path.exists(backup_folder):
             os.makedirs(backup_folder)
         backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
-
         with open(backup_file, 'ab') as f:
             pickle.dump(self.shape.__dict__, f)
+
         while(True):
-            vectors_data = []
             missingVector.append(missingSamples)
             self.logger.debug("Expected Samples: %d" % expected, extra=self.format)
             self.logger.debug("Missing Samples: %d" % missingSamples, extra=self.format)
@@ -362,42 +361,9 @@ class Simulator:
                 self.logger.debug("The entire block is available at step %d, with failure rate %d !" % (steps, self.shape.failureRate), extra=self.format)
                 missingVector.append(missingSamples)
                 break
-
-            for i in range(0, self.shape.numberNodes):
-                validator_data = {
-                    'validator_ID': self.validators[i].ID,
-                    'rowIDs': list(self.validators[i].rowIDs),
-                    'columnIDs': list(self.validators[i].columnIDs),
-                    'amImalicious': self.validators[i].amImalicious,
-                    'amIaddedToQueue': self.validators[i].amIaddedToQueue,
-                    'msgSentCount': self.validators[i].msgSentCount,
-                    'msgRecvCount': self.validators[i].msgRecvCount,
-                    'sampleSentCount': self.validators[i].sampleSentCount,
-                    'sampleRecvCount': self.validators[i].sampleRecvCount,
-                    'restoreRowCount': self.validators[i].restoreRowCount,
-                    'restoreColumnCount': self.validators[i].restoreColumnCount,
-                    'repairedSampleCount': self.validators[i].repairedSampleCount,
-                    'rowNeighbors': list(self.validators[i].rowNeighbors),
-                    'columnNeighbors': list(self.validators[i].columnNeighbors)
-                }
-                vectors_data.append(validator_data)
-            # Alse store for initNetwork
-            vectors_data += (progressVector,missingVector)
-            backup_folder = f"results/{self.execID}/backup"
-            if not os.path.exists(backup_folder):
-                os.makedirs(backup_folder)  
-            backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
-            with open(backup_file, 'ab') as f:
-                pickle.dump(vectors_data, f)
             steps += 1
-        
 
-        backup_folder = f"results/{self.execID}/backup"
-        if not os.path.exists(backup_folder):
-            os.makedirs(backup_folder)
-        backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
-
-        with open(backup_file, 'ab') as f:  # Open in append binary mode
+        with open(backup_file, 'ab') as f:
             pickle.dump("completed", f)
 
         for i in range(0,self.shape.numberNodes):

--- a/DAS/simulator.py
+++ b/DAS/simulator.py
@@ -277,6 +277,13 @@ class Simulator:
         malicious_nodes_not_added_count = 0
         steps = 0
         unique_run_id = str(uuid.uuid4())
+        backup_folder = f"results/{self.execID}/backup"
+        if not os.path.exists(backup_folder):
+            os.makedirs(backup_folder)
+        backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
+
+        with open(backup_file, 'ab') as f:
+            pickle.dump(self.shape.__dict__, f)
         while(True):
             vectors_data = []
             missingVector.append(missingSamples)
@@ -374,7 +381,7 @@ class Simulator:
                     'columnNeighbors': list(self.validators[i].columnNeighbors)
                 }
                 vectors_data.append(validator_data)
-            
+            # Alse store for initNetwork
             vectors_data += (progressVector,missingVector)
             backup_folder = f"results/{self.execID}/backup"
             if not os.path.exists(backup_folder):

--- a/study.py
+++ b/study.py
@@ -32,11 +32,10 @@ def runOnce(config, shape, execID):
         shape.setSeed(config.randomSeed+"-"+str(shape))
         random.seed(shape.randomSeed)
 
-    unique_run_id = str(uuid.uuid4())
     backup_folder = f"results/{execID}/backup"
     if not os.path.exists(backup_folder):
         os.makedirs(backup_folder)
-    backup_file = os.path.join(backup_folder, f"simulation_data_{unique_run_id}.pkl")
+    backup_file = os.path.join(backup_folder, f"simulation_data_{shape}.pkl")
     with open(backup_file, 'ab') as f:
         pickle.dump(shape.__dict__, f)
     

--- a/study.py
+++ b/study.py
@@ -93,33 +93,6 @@ def study():
             sys.exit(0)  # Exit gracefully if already completed
         else:
             print(incomplete_files)
-            # Load the state (if available)
-            # all_results = []
-            # for incomplete_file in incomplete_files:
-            #     latest_state = None
-            #     try:
-            #         with open(incomplete_file, 'rb') as f:
-            #             items = []
-            #             while True:
-            #                 try:
-            #                     item = pickle.load(f)
-            #                     items.append(item)
-            #                 except EOFError:
-            #                     break
-            #             latest_state = items[-1]  # Assuming state is the last item
-            #     except (OSError, pickle.UnpicklingError) as e:
-            #         print(f"Error loading state from {incomplete_file}: {e}")
-            #     if latest_state:
-            #         try:
-            #             # Assuming configuration file is 'smallConf.py'
-            #             config = importlib.import_module("smallConf")
-            #             results = Parallel(config.numJobs)(delayed(runOnce)(config, shape, execID, latest_state) for shape in config.nextShape())
-            #             all_results.extend(results)  # Collect results from all restarts
-            #         except ModuleNotFoundError as e:
-            #             print(f"Error importing configuration file 'smallConf.py': {e}")
-            #     else:
-            #         print(f"No state found for restart from {incomplete_file}. Skipping.")
-                
             sys.exit(0)
         
     if len(sys.argv) < 2:

--- a/study.py
+++ b/study.py
@@ -147,7 +147,23 @@ def study():
         execID = restart_path.split("/")[1]
         state_file = f"results/{execID}/backup"
         all_completed, incomplete_files, completed_files, completed_shapes = check_simulation_completion(state_file)
-        if all_completed:
+
+        current_shapes = []
+        config = importlib.import_module("smallConf")
+
+        completed_shapes_without_seed = completed_shapes
+        for shape in config.nextShape():
+            shape_dict = copy.deepcopy(shape.__dict__)
+            del shape_dict['randomSeed']
+            current_shapes.append(shape_dict)
+        for shape in completed_shapes_without_seed:
+            if 'randomSeed' in shape:
+                del shape['randomSeed']
+
+        completed_set = {frozenset(shape.items()) for shape in completed_shapes_without_seed}
+        current_set = {frozenset(shape.items()) for shape in current_shapes}
+
+        if all_completed and completed_set == current_set:
             print("Simulation is already completed.")
             sys.exit(0)
         else:

--- a/study.py
+++ b/study.py
@@ -68,8 +68,7 @@ def check_simulation_completion(state_file):
                         items.append(item)
                     except EOFError:
                         break
-                last_item = items[-1]  # Access the last item
-                # print(last_item)
+                last_item = items[-1]
                 if last_item != "completed":
                     all_completed = False
                     incomplete_files.append(full_path)
@@ -110,7 +109,7 @@ def start_simulation(execID, completed_files, completed_shapes, incomplete_files
             del comparison_dict[key]
 
         if any(all(comparison_dict[key] == completed_shape[key] for key in comparison_dict.keys() if key not in ignore_keys) for completed_shape in completed_shapes):
-            print(f"Skipping simulation for shape: {shape.__dict__} (already completed)")
+            logger.info("Skipping simulation for shape (already completed): %s"  % (str(shape.__dict__)), extra=format)
         else:
             results.append(delayed(runOnce)(config, shape, execID))
 
@@ -136,7 +135,6 @@ def study():
         execID = restart_path.split("/")[1]
         state_file = f"results/{execID}/backup"
         all_completed, incomplete_files, completed_files, completed_shapes = check_simulation_completion(state_file)
-        print(completed_shapes)
         if all_completed:
             print("Simulation is already completed.")
             sys.exit(0)


### PR DESCRIPTION
Implement stop and resume functionality:

- Stores simulation state information in pickle files.
- Checks the last item in pickle files to accurately determine simulation completion
- If simulation stop (when we press `ctrl+z` in terminal) then we can restart it using the command `python3 study.py --restart=results/{execID}`